### PR TITLE
example fetch mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1848,6 +1848,15 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3257,6 +3266,16 @@
         }
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
@@ -4408,6 +4427,12 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4606,6 +4631,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "promise-polyfill": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
+      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==",
       "dev": true
     },
     "prompts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-config-prettier": "^8.1.0",
     "eslint-config-typescript": "^3.0.0",
     "jest": "^27.0.1",
+    "jest-fetch-mock": "3.0.3",
     "prettier": "^2.3.0",
     "service-worker-mock": "^2.0.5",
     "ts-jest": "^27.0.1",

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -1,3 +1,5 @@
+import { enableFetchMocks } from 'jest-fetch-mock'
+enableFetchMocks()
 import { handleRequest } from '../src/handler'
 import makeServiceWorkerEnv from 'service-worker-mock'
 
@@ -7,6 +9,14 @@ describe('handle', () => {
   beforeEach(() => {
     Object.assign(global, makeServiceWorkerEnv())
     jest.resetModules()
+  })
+
+  test('example mock fetch', async () => {
+    jest.spyOn(global, 'fetch').mockImplementation(() => Promise.resolve({
+      text: () => Promise.resolve("some body")
+    }))
+    const result = await fetch("http://foo.com").then(r => r.text())
+    expect(result).toEqual("some body")
   })
 
   test('handle GET', async () => {


### PR DESCRIPTION
Not 100% sure how much it's worth adding to the testing examples, as needs will vary.

There's already a simple fetch mock in service-worker-mock, but it didn't seem like it had type definitions out of the box, or maybe I was misusing it.  That's why I added the dependency on jest-fetch-mock.