### PR TITLE
Fix Prettier scripts on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/worker.js",
   "scripts": {
     "build": "webpack",
-    "format": "prettier --write  '*.{json,js}' 'src/**/*.{js,ts}' 'test/**/*.{js,ts}'",
-    "lint": "eslint --max-warnings=0 src && prettier --check '*.{json,js}' 'src/**/*.{js,ts}' 'test/**/*.{js,ts}'",
+    "format": "prettier --write  \"*.{json,js}\" \"src/**/*.{js,ts}\" \"test/**/*.{js,ts}\"",
+    "lint": "eslint --max-warnings=0 src && prettier --check \"*.{json,js}\" \"src/**/*.{js,ts}\" \"test/**/*.{js,ts}\"",
     "test": "jest --config jestconfig.json --verbose"
   },
   "author": "author",


### PR DESCRIPTION
On Windows, running either of the `npm` scripts which call Prettier (`lint' or `format`) fails with "no files matching" errors:

![NPM Output](https://user-images.githubusercontent.com/483470/133068473-617db60d-960c-4b8c-acb7-e01f488af121.png)

It seems like this is because Windows is ignoring the single quotes wrapping the path patterns. Wrapping the patterns with _double_ quotes seems to work fine, and should also work under Linux; at least it does under my WSL install of Ubuntu 18.04.

So this commit just replaces the quotes in the `package.json` script definitions with escaped double quotes.