### PR TITLE
added type annotation for fetch event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { handleRequest } from './handler'
 
-addEventListener('fetch', (event) => {
+addEventListener('fetch', (event: FetchEvent) => {
   event.respondWith(handleRequest(event.request))
 })


### PR DESCRIPTION
The template builds fine after cloning the repo, but after installing stripe-node and importing it in index.ts the build fails with TS7006: Parameter 'event' implicitly has an 'any' type.  This PR fixes that issue.