### PR TITLE
README: fix getting started command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This template is meant to be used with [Wrangler](https://github.com/cloudflare/
 To generate using Wrangler, run this command:
 
 ```bash
-wrangler generate my-ts-project https://github.com/cloudflare/worker-typescript-template
+npm init cloudflare my-app https://github.com/cloudflare/worker-typescript-template
 ```
 
 ### 👩 💻 Developing


### PR DESCRIPTION
The command in the readme no longer works:

```
➜  Projects wrangler generate soapbox-worker https://github.com/cloudflare/worker-typescript-template

✘ [ERROR] Deprecation:

  `wrangler generate` has been deprecated.
  Try running `wrangler init` to generate a basic Worker, or cloning the template repository
  instead:
  
  git clone https://github.com/cloudflare/worker-typescript-template
  
  Please refer to https://developers.cloudflare.com/workers/wrangler/deprecations/#generate for more
  information.
```

Instead use the command from this guide: https://developers.cloudflare.com/workers/get-started/quickstarts/