### PR TITLE
wrangler.toml: remove deprecated fields

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,11 +1,5 @@
 name = "worker-typescript-template"
-type = "javascript"
-zone_id = ""
-account_id = ""
-route = ""
 workers_dev = true
 
 [build]
 command = "npm install && npm run build"
-[build.upload]
-format = "service-worker"


### PR DESCRIPTION
When running `wrangler dev`, I see this message:

```
▲ [WARNING] Processing wrangler.toml configuration:

    - 😶 Ignored: "type":
      Most common features now work out of the box with wrangler, including modules, jsx,
  typescript, etc. If you need anything more, use a custom build.
    - Deprecation: "zone_id":
      This is unnecessary since we can deduce this from routes directly.
    - The "route" field in your configuration is an empty string and will be ignored.
      Please remove the "route" field from your configuration.
    - The "account_id" field in your configuration is an empty string and will be ignored.
      Please remove the "account_id" field from your configuration.
    - Deprecation: "build.upload.format":
      The format is inferred automatically from the code.
```

Since these fields aren't used anymore, remove them.