### PR TITLE
Recommend using wrangler init instead of this template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ʕ •́؈•̀) `worker-typescript-template`
 
+## ⚠️ Warning: This template is no longer maintained
+
+Create TypeScript workers [directly from command-line](https://developers.cloudflare.com/workers/get-started/guide/) using `wrangler init` instead.
+
+---
+
 A batteries included template for kick starting a TypeScript Cloudflare worker project.
 
 ## Note: You must use [wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update) 1.17 or newer to use this template.


### PR DESCRIPTION
This template is the top result on Google when searching "cloudflare workers typescript", but is no longer maintained. We should push folks to use `wrangler init` instead.

(ignore that I forked into the wrong org instead of my profile...)